### PR TITLE
去除標籤 Azure Function App

### DIFF
--- a/MyProjFolder/function_app.py
+++ b/MyProjFolder/function_app.py
@@ -27,7 +27,9 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     else:
         # 如果沒有 <article>，則嘗試從最大的 <div> 標籤提取
         divs = soup.find_all('div')
-        largest_div = max(divs, key=lambda div: len(div.get_text(separator='\n', strip=True)))
+        if divs:
+            largest_div = max(divs, key=lambda div: len(div.get_text(separator='\n', strip=True)))
+            content = largest_div.get_text(separator='\n', strip=True)
         content = largest_div.get_text(separator='\n', strip=True)
 
     if name:

--- a/MyProjFolder/function_app.py
+++ b/MyProjFolder/function_app.py
@@ -4,8 +4,10 @@ from bs4 import BeautifulSoup
 
 app = func.FunctionApp()
 
-@app.route(route="MyHttpTrigger", auth_level=func.AuthLevel.FUNCTION)
-def MyHttpTrigger(req: func.HttpRequest) -> func.HttpResponse:
+#@app.function_name(name="gapj_bs4")
+@app.route(auth_level=func.AuthLevel.FUNCTION)
+
+def testforgalacticproject(req: func.HttpRequest) -> func.HttpResponse:
     logging.info('Python HTTP trigger function processed a request.')
 
     name = req.params.get('name')

--- a/MyProjFolder/function_app.py
+++ b/MyProjFolder/function_app.py
@@ -2,7 +2,10 @@ import logging
 import azure.functions as func
 from bs4 import BeautifulSoup
 
-def main(req: func.HttpRequest) -> func.HttpResponse:
+app = func.FunctionApp()
+
+@app.route(route="MyHttpTrigger", auth_level=func.AuthLevel.FUNCTION)
+def MyHttpTrigger(req: func.HttpRequest) -> func.HttpResponse:
     logging.info('Python HTTP trigger function processed a request.')
 
     name = req.params.get('name')


### PR DESCRIPTION
Hi @johnson9294,

這是我們在這個月初一起 debug 完成的 function app，主要是清除爬蟲網頁回來的 html 標籤，之後再請 AI 進行文章的標籤。
在我確認過後我暫時找不到讓 python function app 不要 routing 的方法，因此在 logic app 中目前使用 HTTP Call 來呼叫這個 function app。

在這個 Pull Request 中我做了兩個變更：
- 我將 Azure Function Python module 從 v1 升級到 v2
- 在找最大的 `div` 過後確認有沒有找到才繼續程式並加入錯誤訊息來讓錯誤發生時能更快辨別錯誤在哪
https://github.com/johnson9294/galacticproject/blob/93b3771a3a66cea2b0a2b19248fb0d5fbc8d339a/MyProjFolder/function_app.py#L34-L38

